### PR TITLE
I2B2UI-240: ONT Search Treeview does not work properly. Bug introduced in #214

### DIFF
--- a/js-ext/bootstrap-treeview/bootstrap-treeview.js
+++ b/js-ext/bootstrap-treeview/bootstrap-treeview.js
@@ -376,7 +376,7 @@
         $.each(node.nodes, function checkStates(index, node) {
 
             // nodeId : unique, incremental identifier
-            node.nodeId = _this.idGenerator;
+            node.nodeId = _this.idGenerator();
 
             // parentId : transversing up the tree
             node.parentId = parent.nodeId;


### PR DESCRIPTION
Fixes bug introduced in #214.  One loading method used reference to function instead of results of function call as the key for inserted nodes.