### PR TITLE
I2B2UI-301: Reloading previous queries is not working

### DIFF
--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -383,7 +383,7 @@ i2b2.CRC.view.QT.addConcept = function(sdx, groupIdx, eventIdx) {
     if (temp.length === 0) {
         //add date constraint to concept if there is a group date range specified{
         if (i2b2.CRC.model.query.groups[groupIdx].events[eventIdx].dateRange !== undefined &&
-            (sdx.dateRange === undefined || (sdx.dateRange.start.length === 0 && sdx.dateRange.end.length === 0))) {
+            (sdx.dateRange === undefined || (sdx.dateRange.start?.length === 0 && sdx.dateRange.end?.length === 0))) {
             // only include date range for specific SDX types
             if (sdx.withDates === true) {
                 if (sdx.dateRange === undefined) sdx.dateRange = {start: "", end: ""};


### PR DESCRIPTION
Fix issue with trying to access length attribute on non-string/undefined object property 