### PR TITLE
I2 b2 UI 322 event based queries expand collapse edit dynamic text

### DIFF
--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -1021,6 +1021,7 @@ i2b2.CRC.view.QT.render = function() {
     // handles chevron expand/collapse chevron animation on click and rerenders the expander text in the SequenceBar
     i2b2.CRC.view.QT.attachSequenceBarChevron();
     $('.SequenceBar.eventLink input.check1').each((idx, element) => i2b2.CRC.view.QT.getFormValues(element));
+    $('.SequenceBar.eventLink input.check2').each((idx, element) => i2b2.CRC.view.QT.getFormValues(element));
 
     $('.QueryGroup .OccursCount', i2b2.CRC.view.QT.containerDiv).on('blur', (event) => {
         // parse (and if needed correct) the number value for days/months/years

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -177,11 +177,7 @@ i2b2.CRC.view.QT.updateEventLinkJoinColumn = function(elem) {
     let eventLinkOpName = $(elem).data('joinColumn');    
     eventLink[eventLinkOpName] = $(elem).val();
     i2b2.CRC.view.QT.getFormValues(elem); 
-    i2b2.CRC.view.QS.clearStatus();
-    
-       
-    
-    //console.log(innerHTML1);
+    i2b2.CRC.view.QS.clearStatus(); 
 };
 // ================================================================================================== //
 
@@ -193,7 +189,7 @@ i2b2.CRC.view.QT.getFormValues = function(elem) {
 
     text = text + $('.joinColumn.day1 option:selected', baseEvent).text();
     text = text + ' ' + $('.aggregateOp.frame1 option:selected', baseEvent).text();
-    text = text + ' ' + 'the occurrence of Event ' + (eventLinkIdx+1); 
+    text = text + ' ' + 'occurrence of Event ' + (eventLinkIdx+1); 
     text = text + ' ' + $('.occurs.occOp option:selected', baseEvent).text();
     text = text + ' ' + 'the ' + $('.joinColumn.day2 option:selected', baseEvent).text();
     text = text + ' ' + $('.aggregateOp.frame2 option:selected', baseEvent).text() + ' occurrence of Event ' + (eventLinkIdx+2);
@@ -223,10 +219,22 @@ i2b2.CRC.view.QT.getFormValues = function(elem) {
 };
 // ================================================================================================== //
 i2b2.CRC.view.QT.updateExpanderText= function(text, baseEvent){  
-    $('.EventAccordion > span', baseEvent).text(text);
+    $('.EventAccordion > button', baseEvent).text(text);
 }
-
 // ================================================================================================== //
+i2b2.CRC.view.QT.accordionChevron= function(){  
+    $('.DateRelationship.collapse.show').each(function(){
+        $(this).parent().find(".EventAccordion button").addClass("expanded");
+    });
+    
+    $('.DateRelationship.collapse').on('shown.bs.collapse', function(){
+        $(this).parent().find(".EventAccordion button").addClass("expanded");
+    }).on('hidden.bs.collapse', function(){
+        $(this).parent().find(".EventAccordion button").removeClass("expanded");
+    });
+}
+// ================================================================================================== //
+
 i2b2.CRC.view.QT.toggleTimeSpan = function(elem) {
     let timeSpanElem = $(elem).parents(".timeSpan").find(".timeSpanField");
     let curState =  timeSpanElem.prop( "disabled");
@@ -991,7 +999,7 @@ i2b2.CRC.view.QT.render = function() {
             icon.removeClass('bi-chevron-up');
             icon.addClass('bi-chevron-down');
         }
-    });
+    });     
 
     $('.QueryGroup', i2b2.CRC.view.QT.containerDiv).on('click', '.DateRangeLbl', (event) => {
         // parse (and if needed correct) the number value for days/months/years
@@ -1008,6 +1016,8 @@ i2b2.CRC.view.QT.render = function() {
             icon.addClass('bi-chevron-down');
         }
     });
+
+    i2b2.CRC.view.QT.accordionChevron();
 
     $('.QueryGroup .OccursCount', i2b2.CRC.view.QT.containerDiv).on('blur', (event) => {
         // parse (and if needed correct) the number value for days/months/years
@@ -1591,6 +1601,8 @@ i2b2.CRC.view.QT.addEvent = function(){
             }
         });
     });
+    
+    i2b2.CRC.view.QT.accordionChevron();
 
     //scroll to newly added event
     qgRoot.find(".event").last().get(0).scrollIntoView({alignToTop:false, behavior: 'smooth', block: 'center' });

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -218,11 +218,13 @@ i2b2.CRC.view.QT.getFormValues = function(elem) {
         text = text + ' ' + $('.time2 option:selected', baseEvent).text();
     }
     
-    console.log(text);
-
-    //check boxes are conditional
-    //set default value for day increment
+    i2b2.CRC.view.QT.updateExpanderText(text, baseEvent);
+   
 };
+// ================================================================================================== //
+i2b2.CRC.view.QT.updateExpanderText= function(text, baseEvent){  
+    $('.EventAccordion > span', baseEvent).text(text);
+}
 
 // ================================================================================================== //
 i2b2.CRC.view.QT.toggleTimeSpan = function(elem) {
@@ -244,7 +246,7 @@ i2b2.CRC.view.QT.toggleTimeSpan = function(elem) {
         parent.find(".timeSpanUnit").val("DAY");
         parent.find(".timeSpanValue").val("");
     }
-
+    i2b2.CRC.view.QT.getFormValues(elem); 
     i2b2.CRC.view.QS.clearStatus();
 };
 // ================================================================================================== //

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -31,7 +31,7 @@ i2b2.CRC.view.QT.validateQuery = function() {
             if(timeSpanValueElem.val().length === 0){
                 timeSpanValueElem.addClass("required");
                 timeSpanValueElem.parent().find(".timeSpanError").removeClass("vhidden");
-                $('.DateRelationship').collapse('show');
+                $(timeSpanValueElem.closest('.DateRelationship')).collapse('show');
                 validQuery = false;
             }else{
                 timeSpanValueElem.removeClass("required");
@@ -223,7 +223,7 @@ i2b2.CRC.view.QT.updateExpanderText= function(text, baseEvent){
     $('.EventAccordion > button', baseEvent).text(text);
 }
 // ================================================================================================== //
-i2b2.CRC.view.QT.accordionChevron= function(){  
+i2b2.CRC.view.QT.attachSequenceBarChevron= function(){  
     $('.DateRelationship.collapse.show').each(function(){
         $(this).parent().find(".EventAccordion button").addClass("expanded");
     });
@@ -1018,7 +1018,9 @@ i2b2.CRC.view.QT.render = function() {
         }
     });
 
-    i2b2.CRC.view.QT.accordionChevron();
+    // handles chevron expand/collapse chevron animation on click and rerenders the expander text in the SequenceBar
+    i2b2.CRC.view.QT.attachSequenceBarChevron();
+    $('.SequenceBar.eventLink input.check1').each((idx, element) => i2b2.CRC.view.QT.getFormValues(element));
 
     $('.QueryGroup .OccursCount', i2b2.CRC.view.QT.containerDiv).on('blur', (event) => {
         // parse (and if needed correct) the number value for days/months/years
@@ -1603,7 +1605,7 @@ i2b2.CRC.view.QT.addEvent = function(){
         });
     });
     
-    i2b2.CRC.view.QT.accordionChevron();
+    i2b2.CRC.view.QT.attachSequenceBarChevron();
 
     //scroll to newly added event
     qgRoot.find(".event").last().get(0).scrollIntoView({alignToTop:false, behavior: 'smooth', block: 'center' });

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -106,7 +106,7 @@ i2b2.CRC.view.QT.enableWhenIfAvail = function() {
     let selectedWhen = $(".QueryGroup.when");
 
     if(selectedWhen.length === 0){
-        $(".whenItem").removeClass("disabled");
+        $(".whenItem").removeClass("disabled");       
     }else{
         $(".whenItem").addClass("disabled");
         selectedWhen.find(".whenItem").removeClass("disabled");
@@ -159,6 +159,7 @@ i2b2.CRC.view.QT.extractEventLinkFromElem = function(elem) {
 i2b2.CRC.view.QT.updateEventLinkOperator = function(elem) {
     let eventLink = i2b2.CRC.view.QT.extractEventLinkFromElem(elem);
     eventLink.operator = $(elem).val();
+    i2b2.CRC.view.QT.getFormValues(elem); 
     i2b2.CRC.view.QS.clearStatus();
 };
 // ================================================================================================== //
@@ -166,15 +167,63 @@ i2b2.CRC.view.QT.updateEventLinkAggregateOp = function(elem) {
     let eventLink = i2b2.CRC.view.QT.extractEventLinkFromElem(elem);
     let eventLinkOpName = $(elem).data('aggregateOp');
     eventLink[eventLinkOpName] = $(elem).val();
-    i2b2.CRC.view.QS.clearStatus();
+    i2b2.CRC.view.QT.getFormValues(elem); 
+    i2b2.CRC.view.QS.clearStatus();       
+       
 };
 // ================================================================================================== //
 i2b2.CRC.view.QT.updateEventLinkJoinColumn = function(elem) {
-    let eventLink = i2b2.CRC.view.QT.extractEventLinkFromElem(elem);
-    let eventLinkOpName = $(elem).data('joinColumn');
+    let eventLink = i2b2.CRC.view.QT.extractEventLinkFromElem(elem);  
+    let eventLinkOpName = $(elem).data('joinColumn');    
     eventLink[eventLinkOpName] = $(elem).val();
+    i2b2.CRC.view.QT.getFormValues(elem); 
     i2b2.CRC.view.QS.clearStatus();
+    
+       
+    
+    //console.log(innerHTML1);
 };
+// ================================================================================================== //
+
+
+i2b2.CRC.view.QT.getFormValues = function(elem) {
+    let eventLinkIdx = $(elem).parents('.eventLink').first().data('eventLinkIdx'); // eventlink idx +1     
+    let baseEvent = $(elem).parents('.eventLink')[0]; 
+    let text = 'The ';
+
+    text = text + $('.joinColumn.day1 option:selected', baseEvent).text();
+    text = text + ' ' + $('.aggregateOp.frame1 option:selected', baseEvent).text();
+    text = text + ' ' + 'the occurrence of Event ' + (eventLinkIdx+1); 
+    text = text + ' ' + $('.occurs.occOp option:selected', baseEvent).text();
+    text = text + ' ' + 'the ' + $('.joinColumn.day2 option:selected', baseEvent).text();
+    text = text + ' ' + $('.aggregateOp.frame2 option:selected', baseEvent).text() + ' occurrence of Event ' + (eventLinkIdx+2);
+    if($('.check1').prop('checked')){
+        text = text + ' ' + 'by';
+        text = text + ' ' + $('.op1 option:selected', baseEvent).text();
+        if ($('.incInt1', baseEvent).val().length === 0){
+            text = text + ' ' + '0'; 
+        } else{
+            text = text + ' ' + $('.incInt1', baseEvent).val();
+        }        
+        text = text + ' ' + $('.time1 option:selected', baseEvent).text();
+    }
+    if($('.check2').prop('checked')){
+        text = text + ' ' + 'and';
+        text = text + ' ' + $('.op2 option:selected', baseEvent).text();
+        if ($('.incInt2', baseEvent).val().length === 0){
+            text = text + ' ' + '0'; 
+        } else{
+            text = text + ' ' + $('.incInt2', baseEvent).val();
+        }        
+        text = text + ' ' + $('.time2 option:selected', baseEvent).text();
+    }
+    
+    console.log(text);
+
+    //check boxes are conditional
+    //set default value for day increment
+};
+
 // ================================================================================================== //
 i2b2.CRC.view.QT.toggleTimeSpan = function(elem) {
     let timeSpanElem = $(elem).parents(".timeSpan").find(".timeSpanField");
@@ -211,21 +260,21 @@ i2b2.CRC.view.QT.extractTimeSpanFromElem = function(elem) {
 i2b2.CRC.view.QT.updateTimeSpanOperator = function(elem) {
     let timeSpan = i2b2.CRC.view.QT.extractTimeSpanFromElem(elem);
     timeSpan.operator = $(elem).val();
-
+    i2b2.CRC.view.QT.getFormValues(elem); 
     i2b2.CRC.view.QS.clearStatus();
 };
 // ================================================================================================== //
 i2b2.CRC.view.QT.updateTimeSpanValue = function(elem) {
     let timeSpan = i2b2.CRC.view.QT.extractTimeSpanFromElem(elem);
     timeSpan.value = $(elem).val();
-
+    i2b2.CRC.view.QT.getFormValues(elem); 
     i2b2.CRC.view.QS.clearStatus();
 };
 // ================================================================================================== //
 i2b2.CRC.view.QT.updateTimeSpanUnit = function(elem) {
     let timeSpan = i2b2.CRC.view.QT.extractTimeSpanFromElem(elem);
     timeSpan.unit = $(elem).val();
-
+    i2b2.CRC.view.QT.getFormValues(elem); 
     i2b2.CRC.view.QS.clearStatus();
 };
 

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -31,6 +31,7 @@ i2b2.CRC.view.QT.validateQuery = function() {
             if(timeSpanValueElem.val().length === 0){
                 timeSpanValueElem.addClass("required");
                 timeSpanValueElem.parent().find(".timeSpanError").removeClass("vhidden");
+                $('.DateRelationship').collapse('show');
                 validQuery = false;
             }else{
                 timeSpanValueElem.removeClass("required");

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -194,7 +194,7 @@ i2b2.CRC.view.QT.getFormValues = function(elem) {
     text = text + ' ' + $('.occurs.occOp option:selected', baseEvent).text();
     text = text + ' ' + 'the ' + $('.joinColumn.day2 option:selected', baseEvent).text();
     text = text + ' ' + $('.aggregateOp.frame2 option:selected', baseEvent).text() + ' occurrence of Event ' + (eventLinkIdx+2);
-    if($('.check1').prop('checked')){
+    if($('.check1', baseEvent).prop('checked')){
         text = text + ' ' + 'by';
         text = text + ' ' + $('.op1 option:selected', baseEvent).text();
         if ($('.incInt1', baseEvent).val().length === 0){
@@ -204,7 +204,7 @@ i2b2.CRC.view.QT.getFormValues = function(elem) {
         }        
         text = text + ' ' + $('.time1 option:selected', baseEvent).text();
     }
-    if($('.check2').prop('checked')){
+    if($('.check2', baseEvent).prop('checked')){
         text = text + ' ' + 'and';
         text = text + ' ' + $('.op2 option:selected', baseEvent).text();
         if ($('.incInt2', baseEvent).val().length === 0){

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -160,7 +160,7 @@ i2b2.CRC.view.QT.extractEventLinkFromElem = function(elem) {
 i2b2.CRC.view.QT.updateEventLinkOperator = function(elem) {
     let eventLink = i2b2.CRC.view.QT.extractEventLinkFromElem(elem);
     eventLink.operator = $(elem).val();
-    i2b2.CRC.view.QT.getFormValues(elem); 
+    i2b2.CRC.view.QT.generateSequenceBarText(elem); 
     i2b2.CRC.view.QS.clearStatus();
 };
 // ================================================================================================== //
@@ -168,7 +168,7 @@ i2b2.CRC.view.QT.updateEventLinkAggregateOp = function(elem) {
     let eventLink = i2b2.CRC.view.QT.extractEventLinkFromElem(elem);
     let eventLinkOpName = $(elem).data('aggregateOp');
     eventLink[eventLinkOpName] = $(elem).val();
-    i2b2.CRC.view.QT.getFormValues(elem); 
+    i2b2.CRC.view.QT.generateSequenceBarText(elem); 
     i2b2.CRC.view.QS.clearStatus();       
        
 };
@@ -177,13 +177,13 @@ i2b2.CRC.view.QT.updateEventLinkJoinColumn = function(elem) {
     let eventLink = i2b2.CRC.view.QT.extractEventLinkFromElem(elem);  
     let eventLinkOpName = $(elem).data('joinColumn');    
     eventLink[eventLinkOpName] = $(elem).val();
-    i2b2.CRC.view.QT.getFormValues(elem); 
+    i2b2.CRC.view.QT.generateSequenceBarText(elem); 
     i2b2.CRC.view.QS.clearStatus(); 
 };
 // ================================================================================================== //
 
 
-i2b2.CRC.view.QT.getFormValues = function(elem) {
+i2b2.CRC.view.QT.generateSequenceBarText = function(elem) {
     let eventLinkIdx = $(elem).parents('.eventLink').first().data('eventLinkIdx'); // eventlink idx +1     
     let baseEvent = $(elem).parents('.eventLink')[0]; 
     let text = 'The ';
@@ -255,7 +255,7 @@ i2b2.CRC.view.QT.toggleTimeSpan = function(elem) {
         parent.find(".timeSpanUnit").val("DAY");
         parent.find(".timeSpanValue").val("");
     }
-    i2b2.CRC.view.QT.getFormValues(elem); 
+    i2b2.CRC.view.QT.generateSequenceBarText(elem); 
     i2b2.CRC.view.QS.clearStatus();
 };
 // ================================================================================================== //
@@ -271,21 +271,21 @@ i2b2.CRC.view.QT.extractTimeSpanFromElem = function(elem) {
 i2b2.CRC.view.QT.updateTimeSpanOperator = function(elem) {
     let timeSpan = i2b2.CRC.view.QT.extractTimeSpanFromElem(elem);
     timeSpan.operator = $(elem).val();
-    i2b2.CRC.view.QT.getFormValues(elem); 
+    i2b2.CRC.view.QT.generateSequenceBarText(elem); 
     i2b2.CRC.view.QS.clearStatus();
 };
 // ================================================================================================== //
 i2b2.CRC.view.QT.updateTimeSpanValue = function(elem) {
     let timeSpan = i2b2.CRC.view.QT.extractTimeSpanFromElem(elem);
     timeSpan.value = $(elem).val();
-    i2b2.CRC.view.QT.getFormValues(elem); 
+    i2b2.CRC.view.QT.generateSequenceBarText(elem); 
     i2b2.CRC.view.QS.clearStatus();
 };
 // ================================================================================================== //
 i2b2.CRC.view.QT.updateTimeSpanUnit = function(elem) {
     let timeSpan = i2b2.CRC.view.QT.extractTimeSpanFromElem(elem);
     timeSpan.unit = $(elem).val();
-    i2b2.CRC.view.QT.getFormValues(elem); 
+    i2b2.CRC.view.QT.generateSequenceBarText(elem); 
     i2b2.CRC.view.QS.clearStatus();
 };
 
@@ -1020,8 +1020,8 @@ i2b2.CRC.view.QT.render = function() {
 
     // handles chevron expand/collapse chevron animation on click and rerenders the expander text in the SequenceBar
     i2b2.CRC.view.QT.attachSequenceBarChevron();
-    $('.SequenceBar.eventLink input.check1').each((idx, element) => i2b2.CRC.view.QT.getFormValues(element));
-    $('.SequenceBar.eventLink input.check2').each((idx, element) => i2b2.CRC.view.QT.getFormValues(element));
+    $('.SequenceBar.eventLink input.check1').each((idx, element) => i2b2.CRC.view.QT.generateSequenceBarText(element));
+    $('.SequenceBar.eventLink input.check2').each((idx, element) => i2b2.CRC.view.QT.generateSequenceBarText(element));
 
     $('.QueryGroup .OccursCount', i2b2.CRC.view.QT.containerDiv).on('blur', (event) => {
         // parse (and if needed correct) the number value for days/months/years

--- a/js-i2b2/cells/CRC/assets/QueryGroups.css
+++ b/js-i2b2/cells/CRC/assets/QueryGroups.css
@@ -498,7 +498,7 @@
 
 .QueryGroup.when .SequenceBar {
     max-height: 12.5em; /*added height for laptops */
-    padding: 0.4em 0.4em 0.4em 0.6em;
+    padding: 0.4em 0.4em 0.4em 0.1em;
     border-right: 1px solid #d8a407;
     border-top: 0px;
     border-bottom: 0px;
@@ -650,6 +650,27 @@
     text-align: center;
 }
 
+.ExpandTrigger:hover{
+    background-color: #F2BE21;
+}
+
+.EventAccordion button:after{
+    font-family: "bootstrap-icons";
+    font-weight: 900;
+    content: '\F282';   
+    font-size: 0.875rem;
+    display: inline-block;    
+    margin-left: 5px;
+}
+
+.EventAccordion button.expanded:after {
+    font-family: "bootstrap-icons";
+    font-size: 0.875rem;
+    font-weight: 900;
+    display: inline-block;    
+    margin-left: 5px;
+    content: "\F286";
+}
 
 
 /* Date Ranges */

--- a/js-i2b2/cells/CRC/assets/QueryGroups.css
+++ b/js-i2b2/cells/CRC/assets/QueryGroups.css
@@ -497,7 +497,7 @@
 }
 
 .QueryGroup.when .SequenceBar {
-    max-height: 5.5em;
+    max-height: 12.5em; /*added height for laptops */
     padding: 0.4em 0.4em 0.4em 0.6em;
     border-right: 1px solid #d8a407;
     border-top: 0px;
@@ -615,6 +615,18 @@
 .QueryGroup.whenItem.disabled {
     cursor: not-allowed! important;
     color: rgba(33, 37, 41, 0.47);
+}
+
+.DateRelationship{
+    background-color: #fff;
+    border-radius: 4px
+}
+
+
+.EventAccordion button{
+    background-color: transparent;
+    border-color: transparent;
+    color: black;
 }
 
 /* Occurs */

--- a/js-i2b2/cells/CRC/assets/QueryGroups.css
+++ b/js-i2b2/cells/CRC/assets/QueryGroups.css
@@ -618,7 +618,7 @@
 }
 
 .DateRelationship{
-    background-color: #fff;
+    background-color: #F3F3F3;
     border-radius: 4px
 }
 
@@ -627,6 +627,7 @@
     background-color: transparent;
     border-color: transparent;
     color: black;
+    padding-bottom:3px;
 }
 
 /* Occurs */
@@ -659,6 +660,7 @@
     font-weight: 900;
     content: '\F282';   
     font-size: 0.875rem;
+    vertical-align: middle;
     display: inline-block;    
     margin-left: 5px;
 }
@@ -667,6 +669,7 @@
     font-family: "bootstrap-icons";
     font-size: 0.875rem;
     font-weight: 900;
+    vertical-align: middle;
     display: inline-block;    
     margin-left: 5px;
     content: "\F286";

--- a/js-i2b2/cells/CRC/templates/EventLink.html
+++ b/js-i2b2/cells/CRC/templates/EventLink.html
@@ -1,54 +1,59 @@
 <div class="SequenceBar eventLink" data-event-Link-Idx="{{index}}">
-    <div>
-        <span>the</span>
-        <select class="form-select form-select-sm joinColumn spacing" data-join-Column="joinColumn1" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateEventLinkJoinColumn(this);">
-            {{#select eventLink.joinColumn1}}
-            <option value="STARTDATE">start of</option>
-            <option value="ENDDATE">end of</option>
-            {{/select}}
-        </select>
-        <select class="form-select form-select-sm aggregateOp spacing" data-aggregate-Op="aggregateOp1" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateEventLinkAggregateOp(this);">
-            {{#select eventLink.aggregateOp1}}
-            <option value="FIRST">the first</option>
-            <option value="LAST">the last</option>
-            <option value="ANY">any</option>
-        {{/select}}
-        </select>
-        <span>occurrence of Event {{increment  index}}</span>
-        <select class="form-select form-select-sm occurs spacing" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateEventLinkOperator(this);">
-            {{#select eventLink.operator}}
-            <option value="LESS">occurs before</option>
-            <option value="LESSEQUAL">occurs on or before</option>
-            <option value="EQUAL">occurs simultaneously with</option>
-            {{/select}}
-        </select>
-        <span>the</span>
-        <select class="form-select form-select-sm joinColumn spacing" data-join-Column="joinColumn2" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateEventLinkJoinColumn(this);">
-            {{#select eventLink.joinColumn2}}
-            <option value="STARTDATE">start of</option>
-            <option value="ENDDATE">end of</option>
-            {{/select}}
-        </select>
-        <select class="form-select form-select-sm aggregateOp spacing" data-aggregate-Op="aggregateOp2" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateEventLinkAggregateOp(this);">
-            {{#select eventLink.aggregateOp2}}
-            <option value="FIRST">the first</option>
-            <option value="LAST">the last</option>
-            <option value="ANY">any</option>
-        {{/select}}
-        </select>
-        <span>occurrence of Event {{increment  index inc=2}}</span>
-    </div>
-    <div>
-        {{#if eventLink.timeSpans.[0].value}}
-            {{> EventLinkTimeSpan index = 0 label= "by" checked="checked" timeSpan=eventLink.timeSpans.[0]}}
-        {{else}}
-            {{> EventLinkTimeSpan index = 0 label= "by" checked="" disabled="disabled" timeSpan=eventLink.timeSpans.[0]}}
-        {{/if}}
-
-        {{#if eventLink.timeSpans.[1].value}}
-            {{> EventLinkTimeSpan index = 1 label= "and" checked="checked" timeSpan=eventLink.timeSpans.[1]}}
-        {{else}}
-            {{> EventLinkTimeSpan index = 1 label= "and" checked="" disabled="disabled" timeSpan=eventLink.timeSpans.[1]}}
-        {{/if}}
-    </div>
+    <div class="accordion" id="whenExpander-{{index}}">
+        <span class="EventAccordion" id="rollUp-{{index}}"><span>The start of the first occurrence of Event 1 occurs before the start of the first occurrence of Event 2 by  &ge;  x day(s) and  &ge;  x day(s) </span><button type="button" data-bs-toggle="collapse" data-bs-target="#expandedContent-{{index}}" aria-expanded="false" aria-controls="expandedContent-{{index}}"> <i aria-hidden="true" class="bi bi-chevron-down"></i><span class="visually-hidden">expand relationship controls</span></button></span>
+        <div class="DateRelationship accordion-collapse collapse me-4 my-2 pt-2 px-3" id="expandedContent-{{index}}" data-bs-parent="#whenExpander-{{index}}">
+            <div class="d-flex flex-wrap align-items-end mb-1">
+                <span>the</span>
+                <select class="form-select form-select-sm joinColumn spacing day1" data-join-Column="joinColumn1" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateEventLinkJoinColumn(this);">
+                    {{#select eventLink.joinColumn1}}
+                    <option value="STARTDATE">start of</option>
+                    <option value="ENDDATE">end of</option>
+                    {{/select}}
+                </select>
+                <select class="form-select form-select-sm aggregateOp spacing frame1" data-aggregate-Op="aggregateOp1" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateEventLinkAggregateOp(this);">
+                    {{#select eventLink.aggregateOp1}}
+                    <option value="FIRST">the first</option>
+                    <option value="LAST">the last</option>
+                    <option value="ANY">any</option>
+                {{/select}}
+                </select>
+                <span>occurrence of Event {{increment  index}}</span>
+                <select class="form-select form-select-sm occurs spacing occOp" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateEventLinkOperator(this);">
+                    {{#select eventLink.operator}}
+                    <option value="LESS">occurs before</option>
+                    <option value="LESSEQUAL">occurs on or before</option>
+                    <option value="EQUAL">occurs simultaneously with</option>
+                    {{/select}}
+                </select>
+                <span>the</span>
+                <select class="form-select form-select-sm joinColumn spacing day2" data-join-Column="joinColumn2" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateEventLinkJoinColumn(this);">
+                    {{#select eventLink.joinColumn2}}
+                    <option value="STARTDATE">start of</option>
+                    <option value="ENDDATE">end of</option>
+                    {{/select}}
+                </select>
+                <select class="form-select form-select-sm aggregateOp spacing frame2" data-aggregate-Op="aggregateOp2" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateEventLinkAggregateOp(this);">
+                    {{#select eventLink.aggregateOp2}}
+                    <option value="FIRST">the first</option>
+                    <option value="LAST">the last</option>
+                    <option value="ANY">any</option>
+                {{/select}}
+                </select>
+                <span>occurrence of Event {{increment  index inc=2}} </span>
+            </div>
+            <div class="d-flex flex-wrap align-items-end">
+                {{#if eventLink.timeSpans.[0].value}}
+                    {{> EventLinkTimeSpan index = 0 label= "by" checked="checked" timeSpan=eventLink.timeSpans.[0]}}
+                {{else}}
+                    {{> EventLinkTimeSpan index = 0 label= "by" checked="" disabled="disabled" timeSpan=eventLink.timeSpans.[0]}}
+                {{/if}}
+                {{#if eventLink.timeSpans.[1].value}}
+                    {{> EventLinkTimeSpan index = 1 label= "and" checked="checked" timeSpan=eventLink.timeSpans.[1]}}
+                {{else}}
+                    {{> EventLinkTimeSpan index = 1 label= "and" checked="" disabled="disabled" timeSpan=eventLink.timeSpans.[1]}}
+                {{/if}}
+            </div>
+        </div>
+       
+    </div><!-- /.accordion -->
 </div>

--- a/js-i2b2/cells/CRC/templates/EventLink.html
+++ b/js-i2b2/cells/CRC/templates/EventLink.html
@@ -1,6 +1,6 @@
 <div class="SequenceBar eventLink" data-event-Link-Idx="{{index}}">
     <div class="accordion" id="whenExpander-{{index}}">
-        <span class="EventAccordion" id="rollUp-{{index}}"><span>The start of the first occurrence of Event 1 occurs before the start of the first occurrence of Event 2 by  &ge;  x day(s) and  &ge;  x day(s) </span><button type="button" data-bs-toggle="collapse" data-bs-target="#expandedContent-{{index}}" aria-expanded="false" aria-controls="expandedContent-{{index}}"> <i aria-hidden="true" class="bi bi-chevron-down"></i><span class="visually-hidden">expand relationship controls</span></button></span>
+        <span class="EventAccordion" id="rollUp-{{index}}"><span>The start of the first occurrence of Event {{increment  index}} occurs before the start of the first occurrence of Event {{increment  index inc=2}}  </span><button type="button" data-bs-toggle="collapse" data-bs-target="#expandedContent-{{index}}" aria-expanded="false" aria-controls="expandedContent-{{index}}"> <i aria-hidden="true" class="bi bi-chevron-down"></i><span class="visually-hidden">expand relationship controls</span></button></span>
         <div class="DateRelationship accordion-collapse collapse me-4 my-2 pt-2 px-3" id="expandedContent-{{index}}" data-bs-parent="#whenExpander-{{index}}">
             <div class="d-flex flex-wrap align-items-end mb-1">
                 <span>the</span>

--- a/js-i2b2/cells/CRC/templates/EventLink.html
+++ b/js-i2b2/cells/CRC/templates/EventLink.html
@@ -1,6 +1,6 @@
 <div class="SequenceBar eventLink" data-event-Link-Idx="{{index}}">
     <div class="accordion" id="whenExpander-{{index}}">
-        <span class="EventAccordion" id="rollUp-{{index}}"><span>The start of the first occurrence of Event {{increment  index}} occurs before the start of the first occurrence of Event {{increment  index inc=2}}  </span><button type="button" data-bs-toggle="collapse" data-bs-target="#expandedContent-{{index}}" aria-expanded="false" aria-controls="expandedContent-{{index}}"> <i aria-hidden="true" class="bi bi-chevron-down"></i><span class="visually-hidden">expand relationship controls</span></button></span>
+        <span class="EventAccordion" id="rollUp-{{index}}"><button class="ExpandTrigger" type="button" data-bs-toggle="collapse" data-bs-target="#expandedContent-{{index}}" aria-expanded="false" aria-controls="expandedContent-{{index}}"><span class="visually-hidden">expand relationship controls</span> The start of the first occurrence of Event {{increment  index}} occurs before the start of the first occurrence of Event {{increment  index inc=2}}</button></span>
         <div class="DateRelationship accordion-collapse collapse me-4 my-2 pt-2 px-3" id="expandedContent-{{index}}" data-bs-parent="#whenExpander-{{index}}">
             <div class="d-flex flex-wrap align-items-end mb-1">
                 <span>the</span>

--- a/js-i2b2/cells/CRC/templates/EventLinkTimeSpan.html
+++ b/js-i2b2/cells/CRC/templates/EventLinkTimeSpan.html
@@ -1,9 +1,9 @@
 <div class="timeSpan" data-time-Span-Idx={{index}}>
     <div class="form-check form-check-inline">
-        <input class="form-check-input" type="checkbox" onclick="javascript:this.blur();i2b2.CRC.view.QT.toggleTimeSpan(this);" {{checked}}/>
+        <input class="form-check-input check{{increment  index}}" type="checkbox" onclick="javascript:this.blur();i2b2.CRC.view.QT.toggleTimeSpan(this);" {{checked}}/>
         <label class="form-check-label">{{label}}</label>
     </div>
-    <select class=" form-select form-select-sm timeSpanOp timeSpanField spacing" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateTimeSpanOperator(this);" {{disabled}}>
+    <select class=" form-select form-select-sm timeSpanOp timeSpanField spacing op{{increment  index}}" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateTimeSpanOperator(this);" {{disabled}}>
         {{#select timeSpan.operator}}
         <option value="GREATER">&#62;</option>
         <option value="GREATEREQUAL">&ge;</option>
@@ -14,11 +14,11 @@
     </select>
     <div class="input-group-main">
         <div class="input-group">
-            <input class="form-control form-control-sm timeSpanValue timeSpanField spacing" type="text" onkeyup="i2b2.CRC.view.QT.updateTimeSpanValue(this);" value="{{timeSpan.value}}" {{disabled}}/>
+            <input class="form-control form-control-sm timeSpanValue timeSpanField spacing incInt{{increment  index}} " type="text" onkeyup="i2b2.CRC.view.QT.updateTimeSpanValue(this);" value="{{timeSpan.value}}" {{disabled}}/>
             <span class="timeSpanError w-100 vhidden">required</span>
         </div>
     </div>
-    <select class="form-select form-select-sm timeSpanUnit timeSpanField spacing" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateTimeSpanUnit(this);" {{disabled}}>
+    <select class="form-select form-select-sm timeSpanUnit timeSpanField spacing time{{increment  index}}" onchange="javascript:this.blur();i2b2.CRC.view.QT.updateTimeSpanUnit(this);" {{disabled}}>
         {{#select timeSpan.unit}}
         <option value="HOUR">hour(s)</option>
         <option value="DAY">day(s)</option>


### PR DESCRIPTION
My first goal was to leverage bootstrap's `.accordion` class and associated JS to avoid writing custom code for the expand/collapse functionality. I also made changes to some aspects of the `.SequenceBar` CSS to accommodate the new style for these controls and I added a flex box to the controls so that they would wrap in smaller screens.

My second goal was to extract the text that is created by the user selections within the `.SequenceBar` and the read-only default text and update the `.SequenceBar` expander label for each selection made by the user. I made the decision to not change the default value of the `.timeSpanField` input, since this would probably require changes to some aspects of the query validation functions. So, for the purposes of the `.SequenceBar` expander text only, the value for those inputs would be zero if left blank.

My third goal was inspired by feedback from teammates, to handle edge cases and negative cases when the user doesn't enter data into the `.timeSpanField` input. I also handled the re-rendering of the `.SequenceBar` expander text in the case that the user deletes an event.