### PR TITLE
added styles to wrap the text when the .ExpandTrigger span is very long

### DIFF
--- a/js-i2b2/cells/CRC/assets/QueryGroups.css
+++ b/js-i2b2/cells/CRC/assets/QueryGroups.css
@@ -708,9 +708,7 @@
     text-align: center;
 }
 
-.ExpandTrigger{
-    display: inline-block;
-    width: 100%;
+.ExpandTrigger{ 
     text-align: left;
     white-space: normal;
 }


### PR DESCRIPTION
Perminder reported that the read-only dynamic text for the date relationship on the "When" panel was bleeding off the edge of the container. I added `white-space: normal` to make the text wrap and `text-align: left` to get the wrapped text to align. 