### PR TITLE
I2 b2 UI 397 redo layout for panel date text style

### DIFF
--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -1846,8 +1846,10 @@ i2b2.events.afterCellInit.add((cell) => {
 
             //HTML template for event
             $.ajax("js-i2b2/cells/CRC/templates/Event.html", {
-                success: (template, status, req) => {
+                success: (template, status, req) => {                   
                     Handlebars.registerPartial("Event", req.responseText);
+                    //init date constraint panel tooltip
+                    $(".dcTooltip").tooltip('show');                    
                 },
                 error: (error) => { console.error("Could not retrieve template: Event.html"); }
             });

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -85,6 +85,10 @@ i2b2.CRC.view.QT.showRun = function() {
             }
         }
 
+        //add the current generated query name
+        $("#crcQtQueryName").val(i2b2.CRC.model.transformedQuery.name)
+            .attr("placeholder", i2b2.CRC.model.transformedQuery.name);
+
         // now show the modal form
         $('body #crcModal div:eq(0)').modal('show');
 
@@ -1679,25 +1683,184 @@ i2b2.CRC.view.QT.addEvent = function(){
     i2b2.CRC.view.QS.clearStatus();
 }
 // ================================================================================================== //
-i2b2.CRC.view.QT.showQueryReport = function(){
+i2b2.CRC.view.QT.showQueryReport = function() {
 
+    // this function is used to generate the report and display the modal window
+    const generateReport = function () {
+        let submittedByUsername;
+        if (i2b2.CRC.view.QT.queryResponse) {
+            // get username from a reloaded query
+            submittedByUsername = i2b2.h.XPath(i2b2.CRC.view.QT.queryResponse, "//query_master/user_id/text()")[0].nodeValue;
+        } else {
+            // this is a query that we have just run so we are the user that ran it
+            submittedByUsername = i2b2.PM.model.login_username;
+        }
+
+        // create lookup dictionaries for concepts/modifiers
+        let concepts = {};
+        let modifiers = {};
+        i2b2.CRC.model.query.groups.forEach((group) => {
+            group.events.forEach((event) => {
+                event.concepts.forEach((concept) => {
+                    if (concept.origData.conceptModified) {
+                        modifiers[concept.origData.conceptModified.sdxInfo.sdxKeyValue] = concept;
+                    } else {
+                        concepts[concept.sdxInfo.sdxKeyValue] = concept;
+                    }
+                });
+            });
+        });
+
+        // function for expanding the panel items
+        let func_expandConcept = function(panelItem, panel) {
+            if (panelItem.modKey) {
+                panelItem.moreInfo = modifiers[panelItem.key];
+            } else {
+                panelItem.moreInfo = concepts[panelItem.key];
+            }
+            // deal with dates
+            if (panelItem.moreInfo.dateRange.start == undefined || panelItem.moreInfo.dateRange.start == "") {
+                panelItem.timingFrom = "earliest date available";
+            } else {
+                panelItem.timingFrom = (new Date(Date.parse(panelItem.moreInfo.dateRange.start))).toLocaleDateString();
+            }
+            if (panelItem.moreInfo.dateRange.end == undefined || panelItem.moreInfo.dateRange.end == "") {
+                panelItem.timingTo = "latest date available";
+            } else {
+                panelItem.timingTo = (new Date(Date.parse(panelItem.moreInfo.dateRange.end))).toLocaleDateString();
+            }
+            panelItem.occurs = panel.occursCount;
+            panelItem.timing = panel.timing;
+        };
+
+
+        /// expand the panels
+        let panels = Object.assign({}, i2b2.CRC.model.transformedQuery.panels);
+        panelKeys = Object.keys(panels);
+        panelKeys.forEach((panelKey, idx, keys) => {
+            if (keys.length > (idx+1)) {
+                if (panels[keys[idx+1]].invert == '1') {
+                    panels[panelKey].next_is_not = true;
+                }
+            }
+            let itemKeys = Object.keys(panels[panelKey].items);
+            itemKeys.forEach((itemKey) => {
+                let panelItem = panels[panelKey].items[itemKey];
+                func_expandConcept(panelItem, panels[panelKey]);
+            });
+        });
+
+        let reportData = {
+            name: i2b2.CRC.ctrlr.QS.QM.name,
+            submittedAt: i2b2.CRC.ctrlr.QS.QI.start_date.toLocaleString().replace(", "," @ "),
+            completedAt: i2b2.CRC.ctrlr.QS.QI.end_date.toLocaleString().replace(", "," @ "),
+            submittedBy: "USERNAME(" + submittedByUsername + ")",
+            runDuration: Number((i2b2.CRC.ctrlr.QS.QI.end_date - i2b2.CRC.ctrlr.QS.QI.start_date) / 1000).toLocaleString(),
+            panels: panels
+        };
+
+        // handle lack of populated panels
+        if (Object.keys(panels).length === 0) delete reportData.panels;
+
+        // handle events
+        reportData.events = i2b2.CRC.model.transformedQuery.subQueries;
+        reportData.events.forEach((event, idx) => {
+            event.panels.forEach((panel, idx) => {
+                panel.items.forEach((item, idx) => {
+                    func_expandConcept(item, panel);
+                });
+            });
+        });
+
+        // handle event links
+        let eventLinks = i2b2.CRC.model.query.groups.filter(group => group.when);
+        // there should only be one "when" group
+        if (eventLinks.length) {
+            reportData.eventLinks = eventLinks[0].eventLinks;
+            reportData.eventLinks.forEach((evtlnk, idx) => {
+                evtlnk.prevNum = idx + 1;
+                evtlnk.nextNum = idx + 2;
+            });
+        }
+
+        // deal with the temporal constraint description
+        switch(i2b2.CRC.model.transformedQuery.queryTiming) {
+            case "ANY":
+                reportData.temporalMode = "Treat All Groups Independently";
+                break;
+            case "SAMEVISIT":
+                reportData.temporalMode = "Selected groups occur in the same financial encounter";
+                break;
+            case "SAMEINSTANCENUM":
+                reportData.temporalMode = "Items Instance will be the same";
+                break;
+        }
+
+        // Deal with the reports
+        let reports = [];
+        let graphs = $("#breakdownChartsBody>div");
+        let charts = $("#breakdownDetails>div");
+        let dataRef = i2b2.CRC.ctrlr.QS.breakdowns.resultTable;
+        for (let i=0; i<dataRef.length; i++) {
+            if (i == 0) {
+                reports.push({chart:charts[i].outerHTML, data: dataRef[i]});
+            } else {
+                reports.push({chart:charts[i].outerHTML, graph:graphs[i-1].outerHTML, data: dataRef[i]});
+            }
+        }
+        reportData.reports = reports;
+
+
+        let func_Display = function() {
+            // populate the document in the iframe
+            const reportHtml = i2b2.CRC.view.QT.template.queryReport(reportData);
+            const reportDocument = $('#queryReportWindow')[0].contentWindow.document;
+            reportDocument.open();
+            reportDocument.write(reportHtml);
+            reportDocument.close();
+            // show report
+            $("#queryReportModal div:eq(0)").modal('show');
+        }
+
+        // populate the user's real name via AJAX then display the report window
+        i2b2.PM.ajax.getUser("CRC:PrintQuery", {user_id:submittedByUsername}, (results) => {
+            try {
+                results.parse();
+                let data = results.model[0];
+                if (data.full_name) reportData.submittedBy = data.full_name;
+            } catch (e) {}
+            func_Display();
+        });
+
+
+    };
+
+    // load the modal window if needed
     let queryReportModal = $('body #queryReportModal');
     if (queryReportModal.length === 0) {
         queryReportModal = $("<div id='queryReportModal'/>").appendTo("body");
+        $.ajax("js-i2b2/cells/CRC/assets/modalQueryReport.html", {
+            success: (content) => {
+                queryReportModal.html(content);
+
+                // Attach print function
+                const reportWindow = $('#queryReportWindow')[0].contentWindow;
+                $('#queryReportModal button.print').on('click', () => {
+                    // automatically hide the preview modal
+                    $('#queryReportModal .modal').modal('hide');
+                    // print the document
+                    reportWindow.print();
+                });
+                generateReport();
+            },
+            error: () => {
+                alert("Error: cannot load report template!");
+            }
+        });
+    } else {
+        generateReport();
     }
-
-    let data = {};
-    $(i2b2.CRC.view.QT.template.queryReport(data)).appendTo(queryReportModal);
-
-    // Attach print function
-    const reportWindow = $('#queryReportWindow')[0].contentWindow;
-    const printBtn = $('#queryReportModal button.print');
-    printBtn.unbind('click');
-    printBtn.on('click', () => {reportWindow.print(); });
-
-
-    $("#queryReportModal div:eq(0)").modal('show');
-}
+};
 
 // ================================================================================================== //
 i2b2.CRC.view.QT.showOptions = function() {
@@ -1737,7 +1900,7 @@ i2b2.events.afterCellInit.add((cell) => {
                                 '<label>Name:</label>' +
                             '</div>' +
                         '</div>');
-                    let queryName = $('<input id="queryName" class="name">');
+                    let queryName = $('<input id="queryName" class="name" disabled>');
                     $('<div class="center"></div>').append(queryName).appendTo(runBar);
                     runBar.append('<div class="right">' +
                         '<button type="button" class="btn btn-primary btn-sm button-run">Find Patients</button>' +
@@ -1898,7 +2061,7 @@ i2b2.events.afterCellInit.add((cell) => {
                 error: (error) => { console.error("Could not retrieve template: ConceptDateConstraint.html"); }
             });
 
-            //template for the setting date constraint on concept
+            //template for the Query Report
             $.ajax("js-i2b2/cells/CRC/templates/QueryReport.html", {
                 success: (template) => {
                     cell.view.QT.template.queryReport = Handlebars.compile(template);

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -1095,9 +1095,9 @@ i2b2.CRC.view.QT.render = function() {
 
     $('body').on('click', '.refreshStartDate, .refreshEndDate', (event) => {
         let jqTarget = $(event.target);
-        let dateElement = jqTarget.parents(".dateRange").find(".DateStart");
+        let dateElement = jqTarget.parents(".dateRange").find(".DateStart, .DateRangeStart");
         if (dateElement.length === 0) {
-            dateElement = jqTarget.parents(".dateRange").find(".DateEnd");
+            dateElement = jqTarget.parents(".dateRange").find(".DateEnd, .DateRangeEnd");
         }
         dateElement.val("");
         dateElement.trigger("change");

--- a/js-i2b2/cells/CRC/assets/QueryGroups.css
+++ b/js-i2b2/cells/CRC/assets/QueryGroups.css
@@ -186,8 +186,6 @@
     width: 15em;
 }
 
-
-
 .QueryGroup .DateRangeBody {
     max-height: 10em;
 }
@@ -207,6 +205,12 @@
 .gj-icon{
     top: 5px!important;
     left: 8px!important;
+}
+
+.tooltip-inner ul{
+    text-align: left!important;
+    margin-bottom: 0!important;
+    
 }
 
 .OccursCount {

--- a/js-i2b2/cells/CRC/assets/QueryGroups.css
+++ b/js-i2b2/cells/CRC/assets/QueryGroups.css
@@ -165,6 +165,22 @@
     max-height: 10em;
 }
 
+@media screen and (min-width: 1441px) {
+    .DateOccursBody.expander {
+        max-height: 15em;
+    }
+
+}
+
+@media screen and (min-width: 1835px) {
+    .xxl-flex-row{
+        flex-direction: row!important;
+    }
+    .xxl-flex-pad{
+        padding-left: 0!important;
+    }
+}
+
 .DateOccursBody .dateRange{
     display: flex;
     width: 15em;

--- a/js-i2b2/cells/CRC/assets/QueryGroups.css
+++ b/js-i2b2/cells/CRC/assets/QueryGroups.css
@@ -181,10 +181,12 @@
     }
 }
 
-.DateOccursBody .dateRange{
+.DateOccursBody .dateRange, .DateRangeBody .dateRange {
     display: flex;
     width: 15em;
 }
+
+
 
 .QueryGroup .DateRangeBody {
     max-height: 10em;
@@ -200,6 +202,11 @@
     height: 100%;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
+}
+
+.gj-icon{
+    top: 5px!important;
+    left: 8px!important;
 }
 
 .OccursCount {
@@ -500,8 +507,7 @@
 
 /* Query Group events */
 .QueryGroup.when .event {
-    max-height: 30em;
-    padding-bottom: 1em;
+    max-height: 30em;    
 }
 
 .QueryGroup.when .event.toHide {
@@ -762,6 +768,21 @@
     text-align: right;
 }
 
+.fine-print{
+    font-size: .75rem!important;
+}
+
+.muted-small{
+    color:#757575!important;
+}
+
+.date-w-11{
+    width: 11em!important;
+}
+
+.btn-ref-max-w{
+    max-width: 3em!important;
+}
 
 /* Query Group */
 .QueryGroup {
@@ -801,13 +822,13 @@
 }
 
 .QueryGroup .body .main .content .orDragAdditional {
-    color: #878787;
+    color: #757575;
     font-style: italic;
     margin: 0.9em 0.6em 0.6em 0.6em;
 }
 
 .QueryGroup .body .main .content .dragFirst {
-    color: #878787;
+    color: #757575;
     font-style: italic;
     margin: 3.2em 3em 1.6em 1.6em;
     padding-left: 0.5em;

--- a/js-i2b2/cells/CRC/templates/Event.html
+++ b/js-i2b2/cells/CRC/templates/Event.html
@@ -10,7 +10,7 @@
     <div class="required hidden">at least 1 concept is required</div>
     <div class="DateOccursLbl">SET DATE RANGE OR MULTIPLE OCCURRENCES <i class="bi bi-chevron-down"></i></div>
     <div class="DateOccursBody expander hidden">
-        <div class="d-flex flex-lg-column flex-xxl-row">
+        <div class="d-flex flex-lg-column xxl-flex-row">
             <div class="d-flex flex-row px-3 mb-4">
                 <span class="d-block align-self-end me-2">Concepts must occur between</span>
                 <div class="dateRange align-self-end">
@@ -28,35 +28,30 @@
                     </div>
                     <div style="max-width: 3em;">
                         <button class="btn btn-outline-secondary border-0 refreshEndDate"><i class="bi bi-arrow-clockwise"></i></button>
-                    </div>
-                </div>
-                
-            </div><!-- /.d-flex flex-row -->
-            <div class="d-flex flex-row px-3 mb-4">
-                <span class="d-block align-self-end me-2">Concepts must occur</span>
+                    </div>                   
+                </div>                
+            </div>
+            <div class="d-flex flex-row px-3 mb-4 xxl-flex-pad">
+                <span class="d-block align-self-end me-2">and concepts must occur</span>
                 <div class="align-self-end">
                     <input class="OccursCount form-control" placeholder="1" value="{{this.instances}}" onchange="i2b2.CRC.view.QS.clearStatus();"/>
                 </div>
-                <span class="d-block align-self-end mx-2">or more time(s)</span>
-            </div><!-- /.d-flex flex-row -->
-        </div><!-- /.d-flex flex-row -->
-        
-        
+                <span class="d-block align-self-end mx-2">or more time(s).</span>
+            </div>
+        </div>
     </div>
     <!-- When display -->
     <div class="DateRangeLbl" >SET DATE RANGE <i class="bi bi-chevron-down"></i></div>
-    <div class="DateRangeBody expander hidden">
-        <div style="float:left; width:50%; text-align:center; display:flex; padding:10px 0px">
-            <div style="width:11em; margin:auto; position:relative; text-align:center; ">
-                <div style="font-size: 0.8em;">Concepts must occur between</div>
-                <div style="width:11em;">
-                    <input class="datepicker DateRangeStart" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.start}}" />
-                </div>
-                <div style="font-size: 0.8em;">and</div>
-                <div style="width:11em;">
-                    <input class="datepicker DateRangeEnd" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.end}}" />
-                </div>
+    <div class="DateRangeBody expander hidden">     
+        <div class="d-flex flex-row px-3 mb-4">
+            <span class="d-block align-self-end me-2">Concepts must occur between</span>
+            <div style="width:11em;">
+                <input class="datepicker DateRangeStart" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.start}}" />
             </div>
-        </div>
+            <span class="d-block align-self-end mx-2">and</span>
+            <div style="width:11em;">
+                <input class="datepicker DateRangeEnd" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.end}}" />
+            </div>
+        </div>       
     </div>
 </div>

--- a/js-i2b2/cells/CRC/templates/Event.html
+++ b/js-i2b2/cells/CRC/templates/Event.html
@@ -38,6 +38,7 @@
                 </div>
                 <span class="d-block align-self-center mx-2">or more time(s)</span>
             </div>
+            <span class="fs-5 mb-3 mt-4"><i class="bi bi-info-circle dcTooltip" title="Setting this will apply the date constraint to the entire panel. Any item-level date constraints will be overwritten. Date constraints do not apply on Demographics data, Patient Sets and Previous Queries." data-bs-toggle="tooltip" data-bs-placement="bottom"></i></span>
             <div class="px-3">
                 <ul class="ps-3 fine-print muted-small fst-italic mb-0">
                     <li>Setting this will apply the date constraint to the entire panel</li>
@@ -71,6 +72,7 @@
                     </div>
                 </div> 
             </div>
+            <span class="fs-5 mb-3 mt-4"><i class="bi bi-info-circle dcTooltip" title="Setting this will apply the date constraint to the entire panel. Any item-level date constraints will be overwritten. Date constraints do not apply on Demographics data, Patient Sets and Previous Queries." data-bs-toggle="tooltip" data-bs-placement="top"></i></span>
             <div class="px-3">
                 <ul class="ps-3 fine-print muted-small fst-italic">
                     <li>Setting this will apply the date constraint to the entire panel</li>

--- a/js-i2b2/cells/CRC/templates/Event.html
+++ b/js-i2b2/cells/CRC/templates/Event.html
@@ -8,50 +8,76 @@
     <div class="TermList clear"></div>
     <div class="orDragAdditional">or drag additional concepts</div>
     <div class="required hidden">at least 1 concept is required</div>
-    <div class="DateOccursLbl">SET DATE RANGE OR MULTIPLE OCCURRENCES <i class="bi bi-chevron-down"></i></div>
+    <div class="DateOccursLbl">Set date range and/or occurrence for this entire group/panel <i class="bi bi-chevron-down"></i></div>
     <div class="DateOccursBody expander hidden">
-        <div class="d-flex flex-lg-column xxl-flex-row">
-            <div class="d-flex flex-row px-3 mb-4">
-                <span class="d-block align-self-end me-2">Concepts must occur between</span>
-                <div class="dateRange align-self-end">
-                    <div >
-                        <input class="datepicker DateStart form-control" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.start}}" />
+        <div class="d-flex flex-column">
+            <div class="d-flex flex-row px-3 my-2">
+                <span class="d-block align-self-center me-2">From:</span>
+                <div class="dateRange">
+                    <div class="date-w-11">
+                        <input class="datepicker DateStart form-control form-control-sm" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.start}}" />
                     </div>
-                    <div style="max-width: 3em;">
+                    <div class="btn-ref-max-w">
                         <button class="btn btn-outline-secondary border-0 refreshStartDate"><i class="bi bi-arrow-clockwise"></i></button>
                     </div>
                 </div>            
-                <span class="d-block align-self-end mx-2">and</span>
-                <div class="dateRange align-self-end">
-                    <div>
-                        <input class="datepicker DateEnd form-control" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.end}}"/>
+                <span class="d-block align-self-center mx-2">to:</span>
+                <div class="dateRange">
+                    <div class="date-w-11">
+                        <input class="datepicker DateEnd form-control form-control-sm" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.end}}"/>
                     </div>
-                    <div style="max-width: 3em;">
+                    <div class="btn-ref-max-w">
                         <button class="btn btn-outline-secondary border-0 refreshEndDate"><i class="bi bi-arrow-clockwise"></i></button>
                     </div>                   
                 </div>                
             </div>
-            <div class="d-flex flex-row px-3 mb-4 xxl-flex-pad">
-                <span class="d-block align-self-end me-2">and concepts must occur</span>
-                <div class="align-self-end">
-                    <input class="OccursCount form-control" placeholder="1" value="{{this.instances}}" onchange="i2b2.CRC.view.QS.clearStatus();"/>
+            <div class="d-flex flex-row px-3 mb-2">
+                <span class="d-block align-self-center me-2">Concepts must occur</span>
+                <div>
+                    <input class="OccursCount form-control form-control-sm" placeholder="1" value="{{this.instances}}" onchange="i2b2.CRC.view.QS.clearStatus();"/>
                 </div>
-                <span class="d-block align-self-end mx-2">or more time(s).</span>
+                <span class="d-block align-self-center mx-2">or more time(s)</span>
+            </div>
+            <div class="px-3">
+                <ul class="ps-3 fine-print muted-small fst-italic mb-0">
+                    <li>Setting this will apply the date constraint to the entire panel</li>
+                    <li>Any item-level date constraints will be overwritten</li>
+                    <li>Date constraints do not apply on Demographics data, Patient Sets and Previous Queries</li>
+                </ul>
             </div>
         </div>
     </div>
     <!-- When display -->
-    <div class="DateRangeLbl" >SET DATE RANGE <i class="bi bi-chevron-down"></i></div>
-    <div class="DateRangeBody expander hidden">     
-        <div class="d-flex flex-row px-3 mb-4">
-            <span class="d-block align-self-end me-2">Concepts must occur between</span>
-            <div style="width:11em;">
-                <input class="datepicker DateRangeStart" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.start}}" />
+    <div class="DateRangeLbl" >Set date range and/or occurrence for this entire group/panel<i class="bi bi-chevron-down"></i></div>
+    <div class="DateRangeBody expander hidden">
+        <div class="d-flex flex-column">
+            <div class="d-flex flex-row px-3 mt-2 mb-3">
+                <span class="d-block align-self-center me-2">From:</span>
+                <div class="dateRange">
+                    <div class="date-w-11">
+                        <input class="datepicker DateRangeStart form-control form-control-sm" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.start}}" />
+                    </div>
+                    <div class="btn-ref-max-w">
+                        <button class="btn btn-outline-secondary border-0 refreshStartDate"><i class="bi bi-arrow-clockwise"></i></button>
+                    </div>                      
+                </div>                             
+                <span class="d-block align-self-center mx-2">to:</span>
+                <div class="dateRange">
+                    <div class="date-w-11">
+                        <input class="datepicker DateRangeEnd form-control form-control-sm" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.end}}" />
+                    </div>
+                    <div class="btn-ref-max-w">
+                        <button class="btn btn-outline-secondary border-0 refreshEndDate"><i class="bi bi-arrow-clockwise"></i></button>
+                    </div>
+                </div> 
             </div>
-            <span class="d-block align-self-end mx-2">and</span>
-            <div style="width:11em;">
-                <input class="datepicker DateRangeEnd" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.end}}" />
-            </div>
-        </div>       
+            <div class="px-3">
+                <ul class="ps-3 fine-print muted-small fst-italic">
+                    <li>Setting this will apply the date constraint to the entire panel</li>
+                    <li>Any item-level date constraints will be overwritten</li>
+                    <li>Date constraints do not apply on Demographics data, Patient Sets and Previous Queries</li>
+                </ul>
+            </div> 
+        </div> 
     </div>
 </div>

--- a/js-i2b2/cells/CRC/templates/Event.html
+++ b/js-i2b2/cells/CRC/templates/Event.html
@@ -8,10 +8,10 @@
     <div class="TermList clear"></div>
     <div class="orDragAdditional">or drag additional concepts</div>
     <div class="required hidden">at least 1 concept is required</div>
-    <div class="DateOccursLbl">Set date range and/or occurrence for this entire group/panel <i class="bi bi-chevron-down"></i></div>
+    <div class="DateOccursLbl">Set date range and/or occurrence for this entire panel <i class="bi bi-chevron-down"></i></div>
     <div class="DateOccursBody expander hidden">
         <div class="d-flex flex-column">
-            <div class="d-flex flex-row px-3 my-2">
+            <div class="d-flex flex-row px-3 my-2">               
                 <span class="d-block align-self-center me-2">From:</span>
                 <div class="dateRange">
                     <div class="date-w-11">
@@ -28,8 +28,10 @@
                     </div>
                     <div class="btn-ref-max-w">
                         <button class="btn btn-outline-secondary border-0 refreshEndDate"><i class="bi bi-arrow-clockwise"></i></button>
-                    </div>                   
-                </div>                
+                    </div>
+                    <span class="fs-5 align-self-center ms-2 iconspan"><i class="bi bi-info-circle dcTooltip" title="<ul><li>Setting this will apply the date constraint to the entire panel.</li> <li> Any item-level date constraints will be overwritten.</li> <li> Date constraints do not apply on Demographics data, Patient Sets and Previous Queries.</li> </ul>" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom"></i></span>                      
+                </div>
+                             
             </div>
             <div class="d-flex flex-row px-3 mb-2">
                 <span class="d-block align-self-center me-2">Concepts must occur</span>
@@ -37,19 +39,11 @@
                     <input class="OccursCount form-control form-control-sm" placeholder="1" value="{{this.instances}}" onchange="i2b2.CRC.view.QS.clearStatus();"/>
                 </div>
                 <span class="d-block align-self-center mx-2">or more time(s)</span>
-            </div>
-            <span class="fs-5 mb-3 mt-4"><i class="bi bi-info-circle dcTooltip" title="Setting this will apply the date constraint to the entire panel. Any item-level date constraints will be overwritten. Date constraints do not apply on Demographics data, Patient Sets and Previous Queries." data-bs-toggle="tooltip" data-bs-placement="bottom"></i></span>
-            <div class="px-3">
-                <ul class="ps-3 fine-print muted-small fst-italic mb-0">
-                    <li>Setting this will apply the date constraint to the entire panel</li>
-                    <li>Any item-level date constraints will be overwritten</li>
-                    <li>Date constraints do not apply on Demographics data, Patient Sets and Previous Queries</li>
-                </ul>
-            </div>
+            </div>            
         </div>
     </div>
     <!-- When display -->
-    <div class="DateRangeLbl" >Set date range and/or occurrence for this entire group/panel<i class="bi bi-chevron-down"></i></div>
+    <div class="DateRangeLbl" >Set date range this entire panel<i class="bi bi-chevron-down"></i></div>
     <div class="DateRangeBody expander hidden">
         <div class="d-flex flex-column">
             <div class="d-flex flex-row px-3 mt-2 mb-3">
@@ -70,16 +64,9 @@
                     <div class="btn-ref-max-w">
                         <button class="btn btn-outline-secondary border-0 refreshEndDate"><i class="bi bi-arrow-clockwise"></i></button>
                     </div>
-                </div> 
+                    <span class="fs-5 align-self-center ms-2"><i class="bi bi-info-circle dcTooltip" title="<ul><li>Setting this will apply the date constraint to the entire panel.</li> <li> Any item-level date constraints will be overwritten.</li> <li> Date constraints do not apply on Demographics data, Patient Sets and Previous Queries.</li> </ul>" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom"></i></span> 
+                </div>                
             </div>
-            <span class="fs-5 mb-3 mt-4"><i class="bi bi-info-circle dcTooltip" title="Setting this will apply the date constraint to the entire panel. Any item-level date constraints will be overwritten. Date constraints do not apply on Demographics data, Patient Sets and Previous Queries." data-bs-toggle="tooltip" data-bs-placement="top"></i></span>
-            <div class="px-3">
-                <ul class="ps-3 fine-print muted-small fst-italic">
-                    <li>Setting this will apply the date constraint to the entire panel</li>
-                    <li>Any item-level date constraints will be overwritten</li>
-                    <li>Date constraints do not apply on Demographics data, Patient Sets and Previous Queries</li>
-                </ul>
-            </div> 
         </div> 
     </div>
 </div>

--- a/js-i2b2/cells/CRC/templates/Event.html
+++ b/js-i2b2/cells/CRC/templates/Event.html
@@ -10,38 +10,38 @@
     <div class="required hidden">at least 1 concept is required</div>
     <div class="DateOccursLbl">SET DATE RANGE OR MULTIPLE OCCURRENCES <i class="bi bi-chevron-down"></i></div>
     <div class="DateOccursBody expander hidden">
-        <div style="float:left; width:50%;">
-            <div style="width:16em; margin:auto; position:relative;">
-                <div style="font-size: 0.8em;">Concepts must occur between</div>
-                <div class="dateRange">
+        <div class="d-flex flex-lg-column flex-xxl-row">
+            <div class="d-flex flex-row px-3 mb-4">
+                <span class="d-block align-self-end me-2">Concepts must occur between</span>
+                <div class="dateRange align-self-end">
                     <div >
                         <input class="datepicker DateStart form-control" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.start}}" />
                     </div>
                     <div style="max-width: 3em;">
                         <button class="btn btn-outline-secondary border-0 refreshStartDate"><i class="bi bi-arrow-clockwise"></i></button>
                     </div>
-                </div>
-                <div style="font-size: 0.8em;">and</div>
-                <div class="dateRange">
-                    <div >
+                </div>            
+                <span class="d-block align-self-end mx-2">and</span>
+                <div class="dateRange align-self-end">
+                    <div>
                         <input class="datepicker DateEnd form-control" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateRange.end}}"/>
                     </div>
                     <div style="max-width: 3em;">
                         <button class="btn btn-outline-secondary border-0 refreshEndDate"><i class="bi bi-arrow-clockwise"></i></button>
                     </div>
                 </div>
-            </div>
-        </div>
-        <div style="float:left; width:50%">
-            <div>
-                <div style="font-size: 0.8em;">Concepts must occur</div>
-                <div>
+                
+            </div><!-- /.d-flex flex-row -->
+            <div class="d-flex flex-row px-3 mb-4">
+                <span class="d-block align-self-end me-2">Concepts must occur</span>
+                <div class="align-self-end">
                     <input class="OccursCount form-control" placeholder="1" value="{{this.instances}}" onchange="i2b2.CRC.view.QS.clearStatus();"/>
                 </div>
-                <div style="font-size: 0.8em;">or more time(s)</div>
-
-            </div>
-        </div>
+                <span class="d-block align-self-end mx-2">or more time(s)</span>
+            </div><!-- /.d-flex flex-row -->
+        </div><!-- /.d-flex flex-row -->
+        
+        
     </div>
     <!-- When display -->
     <div class="DateRangeLbl" >SET DATE RANGE <i class="bi bi-chevron-down"></i></div>

--- a/js-i2b2/cells/CRC/templates/EventLink.html
+++ b/js-i2b2/cells/CRC/templates/EventLink.html
@@ -1,6 +1,6 @@
 <div class="SequenceBar eventLink" data-event-Link-Idx="{{index}}">
     <div class="accordion" id="whenExpander-{{index}}">
-        <span class="EventAccordion" id="rollUp-{{index}}"><button class="ExpandTrigger" type="button" data-bs-toggle="collapse" data-bs-target="#expandedContent-{{index}}" aria-expanded="false" aria-controls="expandedContent-{{index}}"><span class="visually-hidden">expand relationship controls</span> The start of the first occurrence of Event {{increment  index}} occurs before the start of the first occurrence of Event {{increment  index inc=2}}</button></span>
+        <span class="EventAccordion" id="rollUp-{{index}}"><button class="ExpandTrigger text-left" type="button" data-bs-toggle="collapse" data-bs-target="#expandedContent-{{index}}" aria-expanded="false" aria-controls="expandedContent-{{index}}"><span class="visually-hidden">expand relationship controls</span> The start of the first occurrence of Event {{increment  index}} occurs before the start of the first occurrence of Event {{increment  index inc=2}}</button></span>
         <div class="DateRelationship accordion-collapse collapse me-4 my-2 pt-2 px-3" id="expandedContent-{{index}}" data-bs-parent="#whenExpander-{{index}}">
             <div class="d-flex flex-wrap align-items-end mb-1">
                 <span>the</span>

--- a/js-i2b2/cells/ONT/assets/Ontology.css
+++ b/js-i2b2/cells/ONT/assets/Ontology.css
@@ -241,7 +241,7 @@ button.invert:hover{
     border: 1px solid #c8cdce;
 }
 
-.srTooltip {
+.srTooltip, .dcTooltip {
     color: #87898a;
 }
 


### PR DESCRIPTION
I reduced the size of the input elements, changed the casing on the expander text, ported some help text from the legacy client and put it into a tooltip, and updated the general form.

I added  classes to the refresh button click function so that the date pickers on the When panel would have consistent functionality with the With and Without panels.  

I also took inline styles and moved them into CSS classes to try to help promote readability of the html in this area. I also took one small liberty outside of this area with related to CSS. I darkened the hex of the classes `.dragFirst` and `.dragAdditional` because the contrast was below AA compliance. I darkened it about 8% to get just over the line. This moved the hex from #878787 to #757575. I discovered the contrast issue when I was going to use #878787 for another element within the date picker form. I ended up not needing the hex, but wanted to keep the improvement to the contrast. If this is bad practice, I can revert it and we can write a ticket for it specifically and I can make those changes there. 