### PR TITLE
added a conditional to hide the validation message when no date is pr…

### DIFF
--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -426,8 +426,11 @@ i2b2.CRC.view.QT.addConceptDateConstraint = function(sdx, callbackFunc) {
 
             let date = moment(startDate, 'MM-DD-YYYY');
             //let isDateValid = date.isValid();
-
-            !isDateValid ? $("#termDateConstraintModal .startDateError").show() : $("#termDateConstraintModal .startDateError").hide();
+            if(!date){
+                $("#termDateConstraintModal .startDateError").hide();
+            } else{
+                !isDateValid ? $("#termDateConstraintModal .startDateError").show() : $("#termDateConstraintModal .startDateError").hide();
+            }            
         }
     });
 
@@ -450,11 +453,20 @@ i2b2.CRC.view.QT.addConceptDateConstraint = function(sdx, callbackFunc) {
 
             let date = moment(endDate, 'MM-DD-YYYY');
             //let isDateValid = date.isValid();
-            !isDateValid ? $("#termDateConstraintModal .endDateError").show() : $("#termDateConstraintModal .endDateError").hide();
+
+            if(!date){
+                $("#termDateConstraintModal .endDateError").hide();
+            } else{
+                !isDateValid ? $("#termDateConstraintModal .endDateError").show() : $("#termDateConstraintModal .endDateError").hide();
+            }
         }
     });
 
     $("#termDateConstraintModal div:eq(0)").modal('show');
+
+    $('.DateStart , .DateEnd').on('focus', function() {
+        $("#termDateConstraintModal .startDateError, #termDateConstraintModal .endDateError").hide();
+    });
 }
 // ================================================================================================== //
 i2b2.CRC.view.QT.renderTermList = function(data, targetEl) {

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -464,9 +464,11 @@ i2b2.CRC.view.QT.addConceptDateConstraint = function(sdx, callbackFunc) {
 
     $("#termDateConstraintModal div:eq(0)").modal('show');
 
-    $('.DateStart , .DateEnd').on('focus', function() {
-        $("#termDateConstraintModal .startDateError, #termDateConstraintModal .endDateError").hide();
-    });
+    $('.DateStart, .DateEnd').on('focus', function() {
+        var $this = $(this);
+        var $error = $this.hasClass('DateStart') ? $("#termDateConstraintModal .startDateError") : $("#termDateConstraintModal .endDateError");
+        $error.hide();
+      });
 }
 // ================================================================================================== //
 i2b2.CRC.view.QT.renderTermList = function(data, targetEl) {

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -426,7 +426,7 @@ i2b2.CRC.view.QT.addConceptDateConstraint = function(sdx, callbackFunc) {
 
             let date = moment(startDate, 'MM-DD-YYYY');
             //let isDateValid = date.isValid();
-            if(!date){
+            if(!startDate){
                 $("#termDateConstraintModal .startDateError").hide();
             } else{
                 !isDateValid ? $("#termDateConstraintModal .startDateError").show() : $("#termDateConstraintModal .startDateError").hide();
@@ -447,14 +447,15 @@ i2b2.CRC.view.QT.addConceptDateConstraint = function(sdx, callbackFunc) {
             startDate = new Date(startDate);
             endDate = new Date(endDate);
 
-            if(startDate > endDate){
+            if(startDateElem.val() && startDate > endDate){
                 startDateElem.datepicker().value("");
+                $("#termDateConstraintModal .startDateError").hide();
             }
 
             let date = moment(endDate, 'MM-DD-YYYY');
             //let isDateValid = date.isValid();
 
-            if(!date){
+            if(!endDate){
                 $("#termDateConstraintModal .endDateError").hide();
             } else{
                 !isDateValid ? $("#termDateConstraintModal .endDateError").show() : $("#termDateConstraintModal .endDateError").hide();
@@ -465,8 +466,8 @@ i2b2.CRC.view.QT.addConceptDateConstraint = function(sdx, callbackFunc) {
     $("#termDateConstraintModal div:eq(0)").modal('show');
 
     $('.DateStart, .DateEnd').on('focus', function() {
-        var $this = $(this);
-        var $error = $this.hasClass('DateStart') ? $("#termDateConstraintModal .startDateError") : $("#termDateConstraintModal .endDateError");
+        let $this = $(this);
+        let $error = $this.hasClass('DateStart') ? $("#termDateConstraintModal .startDateError") : $("#termDateConstraintModal .endDateError");
         $error.hide();
       });
 }


### PR DESCRIPTION
I did 2 things:

- I added an if else statement to check if there's a date present in the field and if not, hide the validation message. If there's a date present, then we do the normal thing of hiding or showing based on whether the date is considered valid based on the regex match.
- I added  code that clears out the validation message when the input field has focus.

I tried each of these things separately and they did not work to fix the issue. Together, however, they did seem to fix it. Now when a user enters alpha characters, then clicks outside the input and then back into the input and then out again, the validation error message is no longer visible (clicking back into the field removes those characters)