### PR TITLE
I2 b2 UI 326 previous queries load more is displayed when there are exact 25 queries

### DIFF
--- a/js-i2b2/cells/CRC/CRC_view_History.js
+++ b/js-i2b2/cells/CRC/CRC_view_History.js
@@ -321,7 +321,8 @@ i2b2.CRC.view.history.LoadQueryMasters = function(maxRecords) {
 
         // display the tree results
         let newNodes = [];
-        for ( let i1=0; i1 < cellResult.model.length; i1++) {
+        let newNodeCount = cellResult.model.length < max ? cellResult.model.length : max;
+        for ( let i1=0; i1 < newNodeCount; i1++) {
             let sdxDataNode = cellResult.model[i1];
             let renderOptions = {
                 title: sdxDataNode.sdxDisplayName ,
@@ -347,7 +348,7 @@ i2b2.CRC.view.history.LoadQueryMasters = function(maxRecords) {
         }
 
         // hide "Load More" link if we have all the records
-        if (newNodes.length < max) {
+        if (cellResult.model.length < max + 1) {
             $('.history-more-bar').addClass("d-none");
         } else {
             $('.history-more-bar').removeClass("d-none");
@@ -375,7 +376,7 @@ i2b2.CRC.view.history.LoadQueryMasters = function(maxRecords) {
 
     let max = maxRecords ? maxRecords : i2b2.CRC.view.history.params.maxQueriesDisp;
     let options = {
-        crc_max_records: max,
+        crc_max_records: max + 1,
         crc_user_type: request_type,
         crc_user_by: user_type
     };


### PR DESCRIPTION
Nick worked with me on this so I'm only going to engage Marc-Danie to review. Nick identified a way to understand how many records are being grabbed from the server so that the condition to show the "load more" link can be evaluated based on that count.