### PR TITLE
I2B2UI-518: add button that initiates search by entered date in query history by date view

### DIFF
--- a/js-i2b2/cells/CRC/assets/QueryHistory.css
+++ b/js-i2b2/cells/CRC/assets/QueryHistory.css
@@ -23,6 +23,10 @@
     z-index: 1000;
 }
 
+#i2b2QueryHistoryBar .gj-icon {
+    top: 9px !important;
+}
+
 
 #i2b2TreeviewQueryHistory .history-container {
     position: absolute;

--- a/js-i2b2/cells/CRC/assets/QueryHistory.css
+++ b/js-i2b2/cells/CRC/assets/QueryHistory.css
@@ -13,6 +13,17 @@
     height: auto;
 }
 
+#i2b2QueryHistoryBar .dateSearchBtn {
+    position:absolute;
+    top: 0.15rem;
+    right: 6rem;
+    padding: 0.5rem;
+    cursor: pointer;
+    font-size: 1.4em !important;
+    z-index: 1000;
+}
+
+
 #i2b2TreeviewQueryHistory .history-container {
     position: absolute;
 }

--- a/js-i2b2/cells/CRC/assets/QueryHistoryBar.html
+++ b/js-i2b2/cells/CRC/assets/QueryHistoryBar.html
@@ -7,6 +7,10 @@
             </div>
             <div class="col-md">
                 <input id="historyDateStart" class="historyDate form-control" placeholder="MM/DD/YYYY" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}" value="{{this.dateStart}}"/>
+                <button class="btn border-0 dateSearchBtn" type="button" id="submitQueryHistoryDate" onclick="this.blur();">
+                    <!-- search is started automatically when focus is taken off the date input field, just give them something else to click to start the process -->
+                    <i class="bi bi-search"></i>
+                </button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This works by causing the user to click a button which takes focus out of the input box.  The way the date picker library works will cause any loss of focus to start a search if the value has changed.