### PR TITLE
I2B2UI-524: Cancel "load more" ONT tree nodes doesn't bork node status

### DIFF
--- a/js-i2b2/cells/ONT/ONT_sdx_CONCPT.js
+++ b/js-i2b2/cells/ONT/ONT_sdx_CONCPT.js
@@ -210,12 +210,12 @@ i2b2.sdx.TypeControllers.CONCPT.LoadChildrenFromTreeview = function(node, onComp
             } else {
                 let cl_node = node;
                 let cb_final = (function (conceptNodes, conceptParents, isCancelled) {
-                    if(!isCancelled) {
+                    if (!isCancelled) {
                         let allNodes = modifierNodes.concat(conceptNodes);
                         let allParents = Array.from(new Set(modifiersParents.concat(conceptParents))); // send only unique values
                         onCompleteCallback(allNodes, allParents);
-                    }else{
-                        onCompleteCallback([],[]);
+                    } else {
+                        onCompleteCallback([],[], true);
                     }
                 });
                 i2b2.sdx.TypeControllers.CONCPT.LoadConcepts(cl_node, cb_final, false);
@@ -368,7 +368,6 @@ i2b2.sdx.TypeControllers.CONCPT.LoadConcepts = function(node, onCompleteCallback
             options.concept_key_value = '';
             break;
     }
-    if (options.version === undefined) options.version = "1.5";
     i2b2.ONT.ajax.GetChildConcepts("ONT:SDX:Concept", options, scopedCallback );
 };
 

--- a/js-i2b2/cells/ONT/ONT_view_Nav.js
+++ b/js-i2b2/cells/ONT/ONT_view_Nav.js
@@ -66,7 +66,7 @@ i2b2.ONT.view.nav.loadChildren =  function(nodeData, onComplete) {
         return;
     }
 
-    i2b2.sdx.TypeControllers.CONCPT.LoadChildrenFromTreeview(nodeData, function(newNodes, parentNodes) {
+    i2b2.sdx.TypeControllers.CONCPT.LoadChildrenFromTreeview(nodeData, function(newNodes, parentNodes, wasCancelled) {
         // change the tiles to contain the counts
         newNodes.forEach((node) => {
             let enablePatientCounts = i2b2.ONT.view.nav.params.patientCounts;
@@ -101,11 +101,13 @@ i2b2.ONT.view.nav.loadChildren =  function(nodeData, onComplete) {
         ]);
 
         // change the treeview icon to show it is no longer loading
-        loadedParents.push({key: nodeData.key, text: nodeData.text}); // make sure we have the orignal node that the load request was fired on
-        i2b2.ONT.view.nav.treeview.treeview('setNodeLoaded', [
-            function(node, parentNodes){ return (parentNodes.filter((d) => (node.key === d.key && node.text === d.text)).length > 0) },
-            loadedParents
-        ]);
+        if (!wasCancelled) {
+            loadedParents.push({key: nodeData.key, text: nodeData.text}); // make sure we have the orignal node that the load request was fired on
+            i2b2.ONT.view.nav.treeview.treeview('setNodeLoaded', [
+                function(node, parentNodes){ return (parentNodes.filter((d) => (node.key === d.key && node.text === d.text)).length > 0) },
+                loadedParents
+            ]);
+        }
 
         // render tree
         i2b2.ONT.view.nav.treeview.treeview('redraw', []);


### PR DESCRIPTION
When loading ONT tree with low "max children" option is selected a prompt shows asking if the setting should be increased and action automatically retried.  If cancel is selected on the prompt then the tree node should return to its previous state (which would allow it to have a load attempt tried again).