### PR TITLE
I2B2UI-592: Query w/previous query as criteria bad call to GetTermInfo

### DIFF
--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -727,8 +727,8 @@ i2b2.CRC.view.QT.addConcept = function(sdx, groupIdx, eventIdx, showLabValues) {
                 }
             }
         }
-    }else{
-        i2b2.CRC.view.QT.labValue.getAndShowLabValues(sdx, groupIdx, eventIdx, !showLabValues);
+    } else {
+        if (sdx.sdxInfo.sdxControlCell === "ONT") i2b2.CRC.view.QT.labValue.getAndShowLabValues(sdx, groupIdx, eventIdx, !showLabValues);
     }
 
     // rerender the query event and add to the DOM


### PR DESCRIPTION
Fix causes calls to GetTermInfo during concept drop only if the dropped concept has a "sdxControlCell" of "ONT" 