### PR TITLE
I2B2UI-904 - Export plugin > Comment is displayed as empty on navigat…

### DIFF
--- a/plugins/edu/harvard/catalyst/data-export/src/components/MakeRequest/index.js
+++ b/plugins/edu/harvard/catalyst/data-export/src/components/MakeRequest/index.js
@@ -144,6 +144,7 @@ export const MakeRequest = () => {
                 minRows={3}
                 inputProps={{ maxLength: 1000 }}
                 multiline
+                value={makeRequestDetails.comments}
                 helperText={"Max: 1,000 characters"}
                 onChange={(event) => updateComments(event.target.value)}
                 InputLabelProps={{ shrink: true }}


### PR DESCRIPTION
…ing away from Request Export page although it is not empty as the same comment is being sent on submitting the request