### PR TITLE
I2B2UI-950: Do not clear existing lab value on close/cancel of modal

### DIFF
--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_BASIC.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_BASIC.js
@@ -38,7 +38,13 @@ i2b2.CRC.view.BASIC = {
 					// populate an empty LabValue entry to the callback function on cancel/close of modal
 					$(labValuesModal).off("hidden.bs.modal"); // prevent multiple bindings
 					$(labValuesModal).on("hidden.bs.modal", function () {
-						if (pluginCallBack) pluginCallBack({...sdxConcept, "LabValues": {}});
+						if (pluginCallBack) {
+							if (sdxConcept.LabValues === undefined) {
+								pluginCallBack({...sdxConcept, "LabValues": {}});
+							} else {
+								pluginCallBack(sdxConcept);
+							}
+						}
 					});
 
 					$("#labValuesModal div").eq(0).modal("show");

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_GENOTYPE_GENE.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_GENOTYPE_GENE.js
@@ -101,7 +101,13 @@ i2b2.CRC.view.GENOTYPE_GENE = {
                 // populate an empty LabValue entry to the callback function on cancel/close of modal
                 $(labValuesModal).off("hidden.bs.modal"); // prevent multiple bindings
                 $(labValuesModal).on("hidden.bs.modal", function () {
-                    if (pluginCallBack) pluginCallBack({...sdxConcept, "LabValues": {}});
+                    if (pluginCallBack) {
+                        if (sdxConcept.LabValues === undefined) {
+                            pluginCallBack({...sdxConcept, "LabValues": {}});
+                        } else {
+                            pluginCallBack(sdxConcept);
+                        }
+                    }
                 });
 
 

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_GENOTYPE_RSID.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_GENOTYPE_RSID.js
@@ -131,7 +131,13 @@ i2b2.CRC.view.GENOTYPE_RSID = {
                 // populate an empty LabValue entry to the callback function on cancel/close of modal
                 $(labValuesModal).off("hidden.bs.modal"); // prevent multiple bindings
                 $(labValuesModal).on("hidden.bs.modal", function () {
-                    if (pluginCallBack) pluginCallBack({...sdxConcept, "LabValues": {}});
+                    if (pluginCallBack) {
+                        if (sdxConcept.LabValues === undefined) {
+                            pluginCallBack({...sdxConcept, "LabValues": {}});
+                        } else {
+                            pluginCallBack(sdxConcept);
+                        }
+                    }
                 });
 
 

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_NUMBER_EXAMPLE.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_NUMBER_EXAMPLE.js
@@ -127,7 +127,13 @@ i2b2.CRC.view.NUMBER_EXAMPLE = {
 				// populate an empty LabValue entry to the callback function on cancel/close of modal
 				$(labValuesModal).off("hidden.bs.modal"); // prevent multiple bindings
 				$(labValuesModal).on("hidden.bs.modal", function () {
-					if (pluginCallBack) pluginCallBack({...sdxConcept, "LabValues": {}});
+					if (pluginCallBack) {
+						if (sdxConcept.LabValues === undefined) {
+							pluginCallBack({...sdxConcept, "LabValues": {}});
+						} else {
+							pluginCallBack(sdxConcept);
+						}
+					}
 				});
 
 				$("#labValuesModal div").eq(0).modal("show");

--- a/plugins/edu/harvard/catalyst/data-export/src/components/DefineTable/index.js
+++ b/plugins/edu/harvard/catalyst/data-export/src/components/DefineTable/index.js
@@ -140,7 +140,7 @@ export const DefineTable = (props) => {
                     let txtLab;
                     let txtMouseover;
                     let labData = cellValues.row.sdxData.LabValues;
-                    if (labData !== undefined && labData.ValueType !== undefined && labData.Value && labData.Value.length !== 0) {
+                    if (labData !== undefined && labData.ValueType !== undefined && ((labData.Value && labData.Value.length !== 0) || labData.ValueFlag || labData.ValueHigh || labData.ValueLow) ) {
                         switch (labData.ValueType) {
                             case undefined:
                                 break;
@@ -149,11 +149,10 @@ export const DefineTable = (props) => {
                                 txtMouseover = labData.Value;
                                 break;
                             case "TEXT":
-                                if(typeof labData.Value ===  'string'){
+                                if (typeof labData.Value ===  'string') {
                                     txtLab = labData.Value;
                                     txtMouseover = labData.Value;
-                                }
-                                else if (labData.Value.length > 1) {
+                                } else if (labData.Value.length > 1) {
                                     txtLab = "(" + labData.Value.length + " values)";
                                     txtMouseover = labData.Value.join('\n');
                                 } else {


### PR DESCRIPTION
This PR also fixes a regression bug that prevents a BETWEEN from being displayed in the Data Exporter plugin.