### PR TITLE
Replaced deprecated filter and syntax for php 8.1 or greater.

### DIFF
--- a/saml-logout.php
+++ b/saml-logout.php
@@ -2,18 +2,18 @@
 
 session_start();
 
-$script = filter_input(INPUT_SERVER, 'SCRIPT_FILENAME', FILTER_SANITIZE_STRING);
-$https = filter_input(INPUT_SERVER, 'HTTPS', FILTER_SANITIZE_STRING);
-$hostname = filter_input(INPUT_SERVER, 'SERVER_NAME', FILTER_SANITIZE_STRING);
-$requestUri = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_STRING);
-$shib_handler = filter_input(INPUT_SERVER, 'AJP_Shib-Handler', FILTER_SANITIZE_STRING);
+$script = filter_input(INPUT_SERVER, 'SCRIPT_FILENAME', FILTER_UNSAFE_RAW);
+$https = filter_input(INPUT_SERVER, 'HTTPS', FILTER_UNSAFE_RAW);
+$hostname = filter_input(INPUT_SERVER, 'SERVER_NAME', FILTER_UNSAFE_RAW);
+$requestUri = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_UNSAFE_RAW);
+$shib_handler = filter_input(INPUT_SERVER, 'AJP_Shib-Handler', FILTER_UNSAFE_RAW);
 
 $scriptFilename = basename($script);
 $path = str_replace($scriptFilename, '', $requestUri);
-$url = (isset($https) && $https === 'on' ? "https" : "http") . "://${hostname}${path}";
+$url = (isset($https) && $https === 'on' ? "https" : "http") . "://{$hostname}{$path}";
 $redir_url = rtrim($url, '/');
 
 unset($_SESSION["eppn"]);
 unset($_SESSION["shib-session-id"]);
 
-header("Location: ${shib_handler}/Logout?return=${redir_url}");
+header("Location: {$shib_handler}/Logout?return={$redir_url}");

--- a/saml-redirect.php
+++ b/saml-redirect.php
@@ -1,14 +1,14 @@
 <?php
 
-$script = filter_input(INPUT_SERVER, 'SCRIPT_FILENAME', FILTER_SANITIZE_STRING);
-$https = filter_input(INPUT_SERVER, 'HTTPS', FILTER_SANITIZE_STRING);
-$hostname = filter_input(INPUT_SERVER, 'SERVER_NAME', FILTER_SANITIZE_STRING);
-$requestUri = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_STRING);
-$shib_handler = filter_input(INPUT_SERVER, 'AJP_Shib-Handler', FILTER_SANITIZE_STRING);
+$script = filter_input(INPUT_SERVER, 'SCRIPT_FILENAME', FILTER_UNSAFE_RAW);
+$https = filter_input(INPUT_SERVER, 'HTTPS', FILTER_UNSAFE_RAW);
+$hostname = filter_input(INPUT_SERVER, 'SERVER_NAME', FILTER_UNSAFE_RAW);
+$requestUri = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_UNSAFE_RAW);
+$shib_handler = filter_input(INPUT_SERVER, 'AJP_Shib-Handler', FILTER_UNSAFE_RAW);
 
 $scriptFilename = basename($script);
 $path = str_replace($scriptFilename, '', $requestUri);
-$url = (isset($https) && $https === 'on' ? "https" : "http") . "://${hostname}${path}saml-acs.php";
+$url = (isset($https) && $https === 'on' ? "https" : "http") . "://{$hostname}{$path}saml-acs.php";
 $redir_url = rtrim($url, '/');
 
-header("Location: ${shib_handler}/Login?target=${redir_url}");
+header("Location: {$shib_handler}/Login?target={$redir_url}");


### PR DESCRIPTION
Updated code for PHP 8.4
- FILTER_SANITIZE_STRING is deprecated as of PHP 8.1.0.
- String interpolation syntax where the dollar sign was placed outside the curly braces is deprecated as of PHP 8.2.