### PR TITLE
I2B2UI-1186: Fix a "stuck" cancel button when canceling a query

### DIFF
--- a/js-i2b2/cells/CRC/CRC_ctrlr_QryMgr.js
+++ b/js-i2b2/cells/CRC/CRC_ctrlr_QryMgr.js
@@ -229,6 +229,9 @@ i2b2.CRC.ctrlr.QueryMgr.cancelQuery = function() {
     i2b2.CRC.ctrlr.QueryMgr.stopQuery();
     i2b2.CRC.model.runner.queued = false;
 
+    // stop the Query Status subsystem from polling
+    i2b2.CRC.QueryStatus.stopPolling();
+
     // update the screen to show status as cancelled
     $("#infoQueryStatusText .statusButtons").removeClass("running").addClass("cancelled");
 }
@@ -242,6 +245,9 @@ i2b2.CRC.ctrlr.QueryMgr.stopQuery = function() {
     i2b2.CRC.model.runner.isCancelled = true;
     i2b2.CRC.model.runner.finished = true;
     i2b2.CRC.model.runner.queued = true;
+
+    // stop the Query Status subsystem from polling
+    i2b2.CRC.QueryStatus.stopPolling();
 
     if (i2b2.CRC.model.runner.intervalTimer !== undefined) {
         clearInterval(i2b2.CRC.model.runner.intervalTimer);
@@ -363,7 +369,7 @@ i2b2.CRC.ctrlr.QueryMgr._callbackGetQueryMaster.callback = function(results) {
         }
 
         // Start the query status panel!
-        i2b2.CRC.QueryStatus.start(i2b2.CRC.model.runner.idQueryInstance, $(".CRC_QS_view")[0]);
+        if (!i2b2.CRC.model.runner.isCancelled) i2b2.CRC.QueryStatus.start(i2b2.CRC.model.runner.idQueryInstance, $(".CRC_QS_view")[0]);
     }
 };
 

--- a/js-i2b2/cells/CRC/CRC_view_QryMgr.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryMgr.js
@@ -34,6 +34,11 @@ i2b2.CRC.view.QueryMgr.clearStatus = function() {
         i2b2.CRC.ctrlr.QueryMgr.tick();
     }
 
+    // deal with hiding cancel and showing run buttons
+    $(".CRC_QT_runbar .button-run").show();
+    $(".CRC_QT_runbar .button-cancel").hide();
+
+
     // clear the query status window
     i2b2.CRC.QueryStatus.clear();
 }

--- a/js-i2b2/cells/CRC/QueryStatus/QueryStatusEngine.js
+++ b/js-i2b2/cells/CRC/QueryStatus/QueryStatusEngine.js
@@ -7,6 +7,7 @@ i2b2.CRC.QueryStatus = {
     currentQueryInstanceId: false,
     displayEl: false,
     resizeObserver: false,
+    haltPolling: false,
     model: {
         QRS: {},
         visualizations: {}
@@ -58,6 +59,10 @@ i2b2.CRC.QueryStatus.obfuscateFloorDisplayNumber = function(number, floorValue, 
     return parseInt(number).toLocaleString();
 };
 
+i2b2.CRC.QueryStatus.stopPolling = function() {
+    i2b2.CRC.QueryStatus.haltPolling = true;
+};
+
 i2b2.CRC.QueryStatus.clear = function() {
     // remove resize observer
     if (i2b2.CRC.QueryStatus.resizeObserver) i2b2.CRC.QueryStatus.resizeObserver.disconnect();
@@ -103,6 +108,8 @@ i2b2.CRC.QueryStatus.clear = function() {
 i2b2.CRC.QueryStatus.start = function(queryInstanceId, mainEl) {
     // restart process only when new query instance id is given
     if (i2b2.CRC.QueryStatus.currentQueryInstanceId !== queryInstanceId) {
+
+        i2b2.CRC.QueryStatus.haltPolling = false;
 
         i2b2.CRC.QueryStatus.model.QRS = {};
         if (typeof i2b2.CRC.QueryStatus.model.visualizations === 'undefined') i2b2.CRC.QueryStatus.model.visualizations = {};
@@ -665,6 +672,9 @@ i2b2.CRC.QueryStatus.createVisualizationsFromList = function() {
 
 
 i2b2.CRC.QueryStatus._handleQueryResultSet = function(results) {
+    // see if polling has been halted or not
+    if (i2b2.CRC.QueryStatus.haltPolling) return;
+
     if (results.error) {
         alert(results.errorMsg);
         return;
@@ -736,6 +746,9 @@ i2b2.CRC.QueryStatus._handleQueryResultSet = function(results) {
 
 
 i2b2.CRC.QueryStatus._handleQueryResultInstance = function(results) {
+    // see if polling has been halted or not
+    if (i2b2.CRC.QueryStatus.haltPolling) return;
+
     if (results.error) {
         console.error("Failed to update " + this.code + " query result instance ID=" + this.id + "! : " + results.errorMsg);
         alert("Failed to get data for Query Result Instance " + this.id + "  of type " + this.type + "!");


### PR DESCRIPTION
Fixes stickness of cancel button after canceling a query.  Also adds new functionality to query status to stop polling of the results if a query is canceled.